### PR TITLE
Create prometheus client to collect requests metrics

### DIFF
--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -1,4 +1,4 @@
-package metrics
+package prometheus
 
 import (
 	"time"

--- a/prometheus/utils.go
+++ b/prometheus/utils.go
@@ -1,0 +1,31 @@
+package prometheus
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/gin-gonic/gin.v1"
+)
+
+func InitRequest(g *gin.Context) {
+	GetClient().OpenRequest(getRequestInfo(g))
+}
+
+func Observe(g *gin.Context, init time.Time) {
+	GetClient().ObserveDuration(getRequestInfo(g), init)
+}
+
+func EndRequest(g *gin.Context) {
+	GetClient().CloseRequest(getRequestInfo(g), strconv.Itoa(g.Writer.Status()))
+}
+
+func getRequestInfo(g *gin.Context) RequestData {
+	path := strings.SplitN(g.Request.URL.Path, "/", 4)
+	return RequestData{
+		Account:   g.Param("account"),
+		Workspace: g.Param("workspace"),
+		Method:    g.Request.Method,
+		Path:      "/" + path[3],
+	}
+}


### PR DESCRIPTION
The main idea of this is to allow us to instrumentalize our services and apps to monitor the the status and duration of each request as well as the number of requests currently in execution.

Metric types: https://prometheus.io/docs/concepts/metric_types/

Example running `GET /metrics` with Colossus:
```
io_http_request_duration_seconds_sum{account="basedevmkp",method="GET",path="/basedevmkp/master/routes",workspace="master"} 3.651740196
io_http_request_duration_seconds_count{account="basedevmkp",method="GET",path="/basedevmkp/master/routes",workspace="master"} 2
# HELP io_http_requests_current The current number of requests in course.
# TYPE io_http_requests_current gauge
io_http_requests_current{account="basedevmkp",method="GET",path="/basedevmkp/master/routes",workspace="master"} 0
# HELP io_http_requests_total The total number of requests which were performed.
# TYPE io_http_requests_total counter
io_http_requests_total{account="basedevmkp",method="GET",path="/basedevmkp/master/routes",status="200",workspace="master"} 2
```

I'm not sure if we should monitor the services considering account and workspace. We can think about using the labels just on infra services and avoid using them on apps. We have to remember that the services keep this data in memory. They are maps in which the key is a hash code created using the labels. Anyway, the service which doesn't need to be monitored considering account or workspace doesn't need to send these values, the labels aren't required.