### PR TITLE
Add labels to identify the service and remove account and workspace

### DIFF
--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -10,17 +10,17 @@ var (
 	requestsMapStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "io_http_requests_total",
 		Help: "The total number of requests which were performed.",
-	}, []string{"account", "workspace", "method", "path", "status"})
+	}, []string{"serviceName", "version", "method", "path", "status"})
 
 	requestsMapCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "io_http_requests_current",
 		Help: "The current number of requests in course.",
-	}, []string{"account", "workspace", "method", "path"})
+	}, []string{"serviceName", "version", "method", "path"})
 
 	requestsMapDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "io_http_request_duration_seconds",
 		Help: "The duration of the requests in seconds.",
-	}, []string{"account", "workspace", "method", "path"})
+	}, []string{"serviceName", "version", "method", "path"})
 )
 
 var client PrometheusClient
@@ -35,7 +35,7 @@ type prometheusClient struct {
 }
 
 type RequestData struct {
-	Account, Workspace, Method, Path string
+	ServiceName, Version, Method, Path string
 }
 
 func (p *prometheusClient) OpenRequest(req RequestData) {
@@ -57,7 +57,7 @@ func (p *prometheusClient) CloseRequest(req RequestData, status string) {
 }
 
 func getDefaultLabels(req RequestData) prometheus.Labels {
-	return prometheus.Labels{"account": req.Account, "workspace": req.Workspace, "method": req.Method, "path": req.Path}
+	return prometheus.Labels{"serviceName": req.ServiceName, "version": req.Version, "method": req.Method, "path": req.Path}
 }
 
 func InitClient() {

--- a/prometheus/utils.go
+++ b/prometheus/utils.go
@@ -2,22 +2,14 @@ package prometheus
 
 import (
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-func MetricsTracker() gin.HandlerFunc {
+func MetricsTracker(serviceName string, version string, path string) gin.HandlerFunc {
 	return func(g *gin.Context) {
-		reqData := getRequestInfo(g)
-		startTracker(g, reqData)
-	}
-}
-
-func MetricsTrackerWithPath(path string) gin.HandlerFunc {
-	return func(g *gin.Context) {
-		reqData := prepareRequestInfo(g, path)
+		reqData := prepareRequestInfo(serviceName, version, path, g)
 		startTracker(g, reqData)
 	}
 }
@@ -32,17 +24,11 @@ func startTracker(g *gin.Context, reqData RequestData) {
 	client.CloseRequest(reqData, strconv.Itoa(g.Writer.Status()))
 }
 
-func getRequestInfo(g *gin.Context) RequestData {
-	pathSplitted := strings.SplitN(g.Request.URL.Path, "/", 4)
-	path := "/" + pathSplitted[3]
-	return prepareRequestInfo(g, path)
-}
-
-func prepareRequestInfo(g *gin.Context, path string) RequestData {
+func prepareRequestInfo(serviceName string, version string, path string, g *gin.Context) RequestData {
 	return RequestData{
-		Account:   g.Param("account"),
-		Workspace: g.Param("workspace"),
-		Method:    g.Request.Method,
-		Path:      path,
+		ServiceName: serviceName,
+		Version:     version,
+		Method:      g.Request.Method,
+		Path:        path,
 	}
 }


### PR DESCRIPTION
- Add labels to identify the service (name and version);
- Remove fields of account and workspace. They should be optional considering the number of metrics which are generated.