### PR TITLE
Handle errors when pinging Redis pub/sub connection

### DIFF
--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -98,7 +98,11 @@ func (r *redisPubSub) mainLoop() {
 	for {
 		select {
 		case <-pingTicker.C:
-			r.subscriptionConn.Ping("")
+			err := r.subscriptionConn.Ping("")
+			if err != nil {
+				logError(err, "pubsub_ping_error", r.keyNamespace, "", "Redis error pinging pub/sub connection")
+				r.recoverPubSubConn()
+			}
 		case msg := <-msgChan:
 			r.send(msg.Pattern, msg.Data)
 		}


### PR DESCRIPTION
#### What is the purpose of this pull request?
To stop ignoring errors when pinging to the pub/sub connection to Redis.

We add this behavior as a way to make sure the connection is kept alive, but in
case it happens to fail for some reason we should recover as soon as possible so
don't ignore any errors when pinging to it.

#### What problem is this solving?
Possibly losing connection to Redis without recovering as soon as possible which
would lead to loss of events.

#### How should this be manually tested?
 - Run colossus locally
 - Subscribe a client locally via curl for example
 - After Colossus is connected to redis, try killing the instance for example and check the ping errors start happening as soon as possible
 - Any events should naturally not reach the connected client at this point
 - Bring local Redis back up
 - Make sure connection has been restored
 - Make sure client starts receiving the events again (his connection shouldn't have been killed)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
