### PR TITLE
Fix Redis pub/sub deadlock for SSE events

### DIFF
--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -34,44 +34,6 @@ func NewPubSub(endpoint, keyNamespace string) (PubSub, error) {
 	return pubsub, nil
 }
 
-type subscription struct {
-	mu       sync.RWMutex
-	patterns []string
-	sendCh   chan<- []byte
-	done     chan struct{}
-}
-
-func newSubscription(patterns []string) (*subscription, <-chan []byte) {
-	subChan := make(chan []byte, 1)
-	sub := &subscription{
-		patterns: patterns,
-		sendCh:   subChan,
-		done:     make(chan struct{}),
-	}
-	return sub, subChan
-}
-
-func (s *subscription) Send(data []byte) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	select {
-	case s.sendCh <- data:
-		return true
-	case <-s.done:
-		return false
-	}
-}
-
-func (s *subscription) Close() {
-	close(s.done)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	close(s.sendCh)
-}
-
 type redisPubSub struct {
 	*redisC
 

--- a/redis/subscription.go
+++ b/redis/subscription.go
@@ -1,0 +1,41 @@
+package redis
+
+import "sync"
+
+type subscription struct {
+	mu       sync.RWMutex
+	patterns []string
+	sendCh   chan<- []byte
+	done     chan struct{}
+}
+
+func newSubscription(patterns []string) (*subscription, <-chan []byte) {
+	subChan := make(chan []byte, 1)
+	sub := &subscription{
+		patterns: patterns,
+		sendCh:   subChan,
+		done:     make(chan struct{}),
+	}
+	return sub, subChan
+}
+
+func (s *subscription) Send(data []byte) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	select {
+	case s.sendCh <- data:
+		return true
+	case <-s.done:
+		return false
+	}
+}
+
+func (s *subscription) Close() {
+	close(s.done)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	close(s.sendCh)
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to fix some timeout errors that have been
occurring with Colossus' SSE events, making IO
developers get stuck without logs during a link
whilst toolbelt keeps vomitting status code errors
when connection to the log or event server (both are
colossus, using the same underlying Redis pub/sub).

#### What problem is this solving?
The problem was grabbing an RLock while trying
to send to the sendCh, whilst there could be
no one on the receiving side anymore and the
channel send getting blocked forever. That would
block forever while holding an RLock, preventing
anyone else from changing the subscriptions state,
including the deactivation of that exact same sub.

For that, added a done channel to the subscription
struct and a lock to safely guarantee that we don't
try to send on a potentially closed channel.

#### How should this be manually tested?
 - Launch colossus
 - Test SSE still work
 - Release new version
 - Continue monitoring number of Colossus go-routines
to make sure they don't grow again
(somewhere in Prometheus :wasabihelp:)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.