### PR TITLE
Fix raw bytes response deserialization

### DIFF
--- a/redis/cache.go
+++ b/redis/cache.go
@@ -52,7 +52,7 @@ func (r *redisC) Get(key string, result interface{}) (bool, error) {
 	}
 
 	if bytes, ok := reply.([]byte); !ok {
-		return false, errors.Errorf("Unrecognized Redis response: %s", reply)
+		return false, errors.Errorf("Redis response for command GET wasn't a []byte: %s", reply)
 	} else if bytesRes, isBytesPtr := result.(*[]byte); isBytesPtr {
 		*bytesRes = bytes
 		return true, nil
@@ -75,7 +75,7 @@ func (r *redisC) Exists(key string) (bool, error) {
 
 	keyExists, isBool := reply.(bool)
 	if !isBool {
-		return false, errors.Errorf("Unrecognized Redis response: %s", reply)
+		return false, errors.Errorf("Redis response for command EXISTS wasn't a bool: %s", reply)
 	}
 	return keyExists, nil
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
To fix a bug just introduced by https://github.com/vtex/go-io/pull/17 that was
treating an error response as actually a successful assignment to a byte slice.

Choose a more explicit approach of actually type-checking on the `result` output
argument to make the code clearer (would probably make the previous bug obvious).

Also improved error messages, which was a request by @terciodemelo on the other PR
and I didn't see it before merging.

#### What problem is this solving?
A bug affecting *all* usages of `Redis` client (it'd return `ok` without having actually
unmarshalled the JSON response to the result object)

#### How should this be manually tested?
 - Launch apps with file cache in Redis and this new version
 - Panics should not happen when processing responses from Redis

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
