### PR TITLE
Use redis reply helpers for conversions

### DIFF
--- a/redis/cache.go
+++ b/redis/cache.go
@@ -45,10 +45,10 @@ func (r *redisC) Get(key string, result interface{}) (bool, error) {
 	}
 
 	reply, err := redis.Bytes(r.doCmd("GET", key))
-	if err != nil {
-		return false, errors.WithStack(err)
-	} else if reply == nil {
+	if err == redis.ErrNil {
 		return false, nil
+	} else if err != nil {
+		return false, errors.WithStack(err)
 	}
 
 	if bytesRes, isBytesPtr := result.(*[]byte); isBytesPtr {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the Exists bug and potentially others.

Exists method was breaking as Redis returns an int instead
of a bool. Just use the redis.Bool helper which already
handles the int->bool conversion as well.

Also use it for GET, as it handles when the response is a string as well.

https://godoc.org/github.com/gomodule/redigo/redis#hdr-Reply_Helpers

#### What problem is this solving?
Exists not working due to wrong type assertion.

#### How should this be manually tested?
 - Launch that apps with registry caching and :magic:

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.