### PR TITLE
Increase vendor name size to up to 50 chars

### DIFF
--- a/identifier/parsing.go
+++ b/identifier/parsing.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const vendorPattern string = `[a-z][a-z0-9-]{0,18}[a-z0-9]`
+const vendorPattern string = `[a-z][a-z0-9-]{0,48}[a-z0-9]`
 const namePattern string = `[a-z][a-z0-9-]{0,126}[a-z0-9]`
 const enginePattern string = vendorPattern
 const tagPattern string = vendorPattern


### PR DESCRIPTION
Account names can have up to 50 characters, so
that is what vendors max size should be.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.