### PR TITLE
Fix: logrus new import path (sirupsen/logrus#1041)

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -1,8 +1,8 @@
 package cache
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // ensureValidCacheKey is a utility function that centralizes checking of keys that is repeated in many functions.

--- a/ioext/chunkedData.go
+++ b/ioext/chunkedData.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin/render"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const pingDelay = 60 * time.Second

--- a/redis/pubsubClient.go
+++ b/redis/pubsubClient.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type pubsubClient struct {

--- a/redis/util.go
+++ b/redis/util.go
@@ -1,7 +1,7 @@
 package redis
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func logError(err error, code, namespace, key, msg string) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix logrus import problems:
```
    github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.4.2: parsing go.mod:
    module declares its path as: github.com/sirupsen/logrus
            but was required as: github.com/Sirupsen/logrus
```

#### What problem is this solving?
When using this repository with new logrus versions, I got `module declares` error.
More details here: https://github.com/sirupsen/logrus/issues/1041


#### How should this be manually tested?
Just try to build some golang project using this repo as dependency.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
