### PR TITLE
Fix Redis connection concurrent usage

### DIFF
--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -239,8 +239,9 @@ func connReceiveChan(ctx context.Context, conn *redis.PubSubConn, oldChan <-chan
 			if conn.Conn.Err() != nil {
 				return
 			}
+			msg := conn.Receive()
 			select {
-			case msgChan <- conn.Receive():
+			case msgChan <- msg:
 			case <-ctx.Done():
 				return
 			}

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"sync"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -11,7 +10,6 @@ import (
 const pongTimeout = 5 * time.Second
 
 type subConn struct {
-	mu         sync.Mutex
 	pool       *redis.Pool
 	outputChan chan redis.Message
 
@@ -103,11 +101,9 @@ func (c *subConn) mainLoop() {
 				continue
 			}
 
-			c.mu.Lock()
 			for _, pattern := range patterns {
 				c.subscribedPatterns[pattern] = true
 			}
-			c.mu.Unlock()
 
 		case patterns := <-c.unsubscribeChan:
 			if err := c.currConn.PUnsubscribe(patterns...); err != nil {
@@ -116,11 +112,9 @@ func (c *subConn) mainLoop() {
 				continue
 			}
 
-			c.mu.Lock()
 			for _, pattern := range patterns {
 				delete(c.subscribedPatterns, pattern)
 			}
-			c.mu.Unlock()
 
 		case msg := <-msgChan:
 			switch v := msg.(type) {
@@ -165,9 +159,6 @@ func (c *subConn) resetConn() error {
 		psc.Close()
 		return errors.Wrap(err, "Failed to subscribe to test channel")
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if len(c.subscribedPatterns) > 0 {
 		patterns := make([]interface{}, 0, len(c.subscribedPatterns))

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -80,7 +80,7 @@ func (c *subConn) ReceiveChan() <-chan redis.Message {
 
 func (c *subConn) mainLoop() {
 	var (
-		pingTicker      = time.NewTicker(pingDelay)
+		pingTicker      = time.Tick(pingDelay)
 		pongTimeoutChan <-chan time.Time
 
 		done    = make(chan struct{})
@@ -94,7 +94,7 @@ func (c *subConn) mainLoop() {
 		msgChan = connReceiveChan(c.currConn, done)
 	}
 	for {
-		err, errCode, errMsg := c.mainIteration(pingTicker.C, &pongTimeoutChan, msgChan, recoverConn)
+		err, errCode, errMsg := c.mainIteration(pingTicker, &pongTimeoutChan, msgChan, recoverConn)
 		if err != nil {
 			logError(err, errCode, "", "", errMsg)
 			recoverConn()
@@ -109,7 +109,7 @@ func (c *subConn) mainIteration(pingTicker <-chan time.Time, pongTimeoutChan *<-
 		if err != nil {
 			return err, "pubsub_ping_error", "Redis error pinging pub/sub connection"
 		}
-		*pongTimeoutChan = time.Tick(pongTimeout)
+		*pongTimeoutChan = time.After(pongTimeout)
 		return nil, "", ""
 
 	case msg := <-msgChan:

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -149,6 +149,9 @@ func (c *subConn) mainIteration(pingTicker <-chan time.Time, pongTimeoutChan *<-
 				delete(c.subscribedPatterns, pattern)
 			}
 		}
+		if len(toUnsubscribe) == 0 {
+			return nil, "", ""
+		}
 
 		if err = c.currConn.PUnsubscribe(toUnsubscribe...); err != nil {
 			// We don't need to retry here, since we've already removed the specific subscriptions

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -61,7 +61,7 @@ func (c *subConn) PSubscribe(patterns []interface{}) error {
 	case c.subscribeChan <- patterns:
 		return nil
 	case <-time.After(subscribeTimeout):
-		return errors.New("Timeout")
+		return errors.New("Timeout sending patterns to subscriptions channel")
 	}
 }
 

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -80,75 +80,74 @@ func (c *subConn) mainLoop() {
 		msgChan = connReceiveChan(c.currConn, done)
 	}
 	for {
-		var (
-			err             error
-			errCode, errMsg string
-		)
-
-		select {
-		case <-pingTicker.C:
-			err = c.currConn.Ping("")
-			if err == nil {
-				pongTimeoutChan = time.Tick(pongTimeout)
-			} else {
-				errCode, errMsg = "pubsub_ping_error", "Redis error pinging pub/sub connection"
-			}
-
-		case <-pongTimeoutChan:
-			pongTimeoutChan = nil
-			err, errCode, errMsg = errors.New("Pong timeout"), "pong_timeout", "Timed out waiting for Redis ping response"
-
-		case patterns := <-c.subscribeChan:
-			if err = c.currConn.PSubscribe(patterns...); err != nil {
-				errCode, errMsg = "subscribe_error", "Redis PSubscribe command error"
-				// Retry at most once otherwise just drop the subscription request.
-				// This is a safety guard (instead of retrying indefinitely), in case
-				// some bad input is sent to us.
-				recover()
-				err = c.currConn.PSubscribe(patterns...)
-				if err != nil {
-					break
-				}
-			}
-
-			for _, pattern := range patterns {
-				c.subscribedPatterns[pattern] = true
-			}
-
-		case patterns := <-c.unsubscribeChan:
-			toUnsubscribe := make([]interface{}, 0, len(patterns))
-			for _, pattern := range patterns {
-				if c.subscribedPatterns[pattern] {
-					toUnsubscribe = append(toUnsubscribe, pattern)
-					delete(c.subscribedPatterns, pattern)
-				}
-			}
-
-			if err = c.currConn.PUnsubscribe(toUnsubscribe...); err != nil {
-				errCode, errMsg = "unsubscribe_error", "Redis PUnsubscribe command error"
-				// We don't need to retry here, since we've already removed the specific subscriptions
-				// from the subscribedPatterns field, so when we recover the connection belo it will
-				// come back already unsubscribed from the requested patterns.
-			}
-
-		case msg := <-msgChan:
-			switch v := msg.(type) {
-			case redis.Message:
-				c.outputChan <- v
-
-			case redis.Pong:
-				pongTimeoutChan = nil
-
-			case error:
-				err, errCode, errMsg = v, "pubsub_error", "Redis pub/sub error"
-			}
-		}
-
+		err, errCode, errMsg := c.mainIteration(pingTicker.C, &pongTimeoutChan, msgChan)
 		if err != nil {
 			logError(err, errCode, "", "", errMsg)
 			recover()
 		}
 	}
+}
+
+func (c *subConn) mainIteration(pingTicker <-chan time.Time, pongTimeoutChan *<-chan time.Time, msgChan <-chan interface{}) (err error, errCode, errMsg string) {
+	select {
+	case <-pingTicker:
+		err = c.currConn.Ping("")
+		if err == nil {
+			*pongTimeoutChan = time.Tick(pongTimeout)
+		} else {
+			errCode, errMsg = "pubsub_ping_error", "Redis error pinging pub/sub connection"
+		}
+
+	case <-*pongTimeoutChan:
+		*pongTimeoutChan = nil
+		err, errCode, errMsg = errors.New("Pong timeout"), "pong_timeout", "Timed out waiting for Redis ping response"
+
+	case patterns := <-c.subscribeChan:
+		if err = c.currConn.PSubscribe(patterns...); err != nil {
+			errCode, errMsg = "subscribe_error", "Redis PSubscribe command error"
+			// Retry at most once otherwise just drop the subscription request.
+			// This is a safety guard (instead of retrying indefinitely), in case
+			// some bad input is sent to us.
+			recover()
+			err = c.currConn.PSubscribe(patterns...)
+			if err != nil {
+				break
+			}
+		}
+
+		for _, pattern := range patterns {
+			c.subscribedPatterns[pattern] = true
+		}
+
+	case patterns := <-c.unsubscribeChan:
+		toUnsubscribe := make([]interface{}, 0, len(patterns))
+		for _, pattern := range patterns {
+			if c.subscribedPatterns[pattern] {
+				toUnsubscribe = append(toUnsubscribe, pattern)
+				delete(c.subscribedPatterns, pattern)
+			}
+		}
+
+		if err = c.currConn.PUnsubscribe(toUnsubscribe...); err != nil {
+			errCode, errMsg = "unsubscribe_error", "Redis PUnsubscribe command error"
+			// We don't need to retry here, since we've already removed the specific subscriptions
+			// from the subscribedPatterns field, so when we recover the connection belo it will
+			// come back already unsubscribed from the requested patterns.
+		}
+
+	case msg := <-msgChan:
+		switch v := msg.(type) {
+		case redis.Message:
+			c.outputChan <- v
+
+		case redis.Pong:
+			pongTimeoutChan = nil
+
+		case error:
+			err, errCode, errMsg = v, "pubsub_error", "Redis pub/sub error"
+		}
+	}
+	return
 }
 
 // Retries to reset pub/sub connection until no error occurrs

--- a/redis/subConn.go
+++ b/redis/subConn.go
@@ -162,9 +162,8 @@ func (c *subConn) mainIteration(pingTicker <-chan time.Time, pongTimeoutChan *<-
 
 // Retries to reset pub/sub connection until no error occurrs
 func (c *subConn) recoverConn() {
-	if err := c.currConn.Conn.Err(); err != nil {
-		logError(err, "redis_conn_error", "", "", "Redis connection error")
-	}
+	err := c.currConn.Conn.Err()
+	logError(err, "redis_conn_recover", "", "", "Recovering Redis connection due to error")
 
 	for {
 		err := c.resetConn()


### PR DESCRIPTION
#### What is the purpose of this pull request?
Earlier this week we got an error on Colossus where a specific instance of
Colossus started getting a "closed connection" error on every subscription
requested by clients. This is the query on Splunk to see how strange that
behavior was: [[Splunk]](https://splunk7.vtex.com/en-US/app/vtex_kuberouter/search?q=search%20index%3Dcolossus%20(code%20IN%20(pubsub_error%20subscription_error%20redis_conn_error%20redis_conn_reset_error))%20%0A%7C%20eval%20count_bad_host%3Dif(host%3D%22colossus0-39-2-dev-66f589bb57-c9t8t%22%2C%201%2C%20null)%0A%7C%20eval%20count_other_hosts%3Dif(host%3D%22colossus0-39-2-dev-66f589bb57-c9t8t%22%2C%20null%2C%201)%0A%7C%20timechart%20sum(count_bad_host)%20sum(count_other_hosts)%20by%20code&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&earliest=1594634400&latest=1594666800&display.general.type=visualizations&display.page.search.tab=visualizations&display.visualizations.trellis.enabled=1&display.visualizations.charting.legend.placement=right&display.visualizations.charting.axisTitleX.visibility=visible&display.visualizations.charting.axisTitleY.visibility=visible&display.visualizations.charting.axisTitleY2.visibility=visible&display.visualizations.trellis.splitBy=_aggregation&display.visualizations.trellis.size=large&display.visualizations.charting.chart=line&display.visualizations.charting.axisY.scale=log&sid=1594938269.735207_B1AFCE35-A4A4-40A6-92E9-145382F27731)

I've looked around the code, and couldn't find any reason how we could
ever get into that weird state, but investigating deeper into the Redis library
that we use, I found that it is actually not thread-safe for concurrent
reads or writes under the same request: [[StackOverflow]](https://stackoverflow.com/questions/37178897/some-questions-about-redigo-and-concurrency) :harold-pain:

So in this PR, apart from moving stuff around to improve overall quality,
I've decided to:
 - Move all commands performed in the redis connection to the single
background loop, thus avoiding any concurrent access to the same
connection;
 - Improve the logs, so that we can have more information in case this
problem ever happens again in the new version;
 - _TODO:_ We should have alarms to know ASAP if the problem happens.

This actually also improves our resiliency, as the request for a command will
be simply sending to a channel which will never fail, while we can afford 
indefinitely retrying the request in the background "main loop". I've made sure
to do only 1, explicit, retry of `PSubscribe` command though, since I'm not
sure if we may end up calling this function with a bad subscription that
always fails when we send to Redis.
(The alternative would be to always add the requested patterns to that
`subscribedPatterns` field, so that if the individual command fails, we'd
retry indefinitely on the "recover connection loop")

#### What problem is this solving?
Concurrent access to a **non** thread-unsafe shared resource.

#### How should this be manually tested?
 - Check the new logs are now sent to Splunk

Stretch (?): 
 - Add some "chaos monkey" code to randomly return an error sometimes
 - Ensure connection recovery works as expected (through those same logs)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
