### PR TITLE
[worker] Sync queue and background processor tools

### DIFF
--- a/redis/stubs/redis.go
+++ b/redis/stubs/redis.go
@@ -1,0 +1,52 @@
+package stubs
+
+import (
+	"time"
+
+	"github.com/vtex/go-io/redis"
+	"github.com/vtex/go-io/reflext"
+)
+
+func NewRedis() redis.Cache {
+	return &stubRedis{}
+}
+
+type stubRedis struct{}
+
+func (r *stubRedis) Get(key string, result interface{}) (bool, error) {
+	return false, nil
+}
+
+func (r *stubRedis) Exists(key string) (bool, error) {
+	return false, nil
+}
+
+func (r *stubRedis) Set(key string, value interface{}, expireIn time.Duration) error {
+	return nil
+}
+
+func (c *stubRedis) GetOrSet(key string, result interface{}, duration time.Duration, fetch func() (interface{}, error)) error {
+	value, err := fetch()
+	if err != nil {
+		return err
+	}
+
+	err = reflext.SetPointer(result, value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *stubRedis) SetOpt(key string, value interface{}, options redis.SetOptions) (bool, error) {
+	return true, nil
+}
+
+func (c *stubRedis) Del(key string) error {
+	return nil
+}
+
+func (c *stubRedis) Incr(key string) (int64, error) {
+	return 0, nil
+}

--- a/worker/backgroundProcessor.go
+++ b/worker/backgroundProcessor.go
@@ -1,0 +1,183 @@
+package housekeeping
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/vtex/go-sdk/utils/metrics"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vtex/apps/cache"
+	"github.com/vtex/go-io/redis"
+)
+
+const generationKey = "Generation"
+
+// BackgroundProcessor is a utility for running jobs in the background, avoiding
+// the rescheduling of the same job by a provided key (used as the account name
+// for now). We avoid receiving a separate function for each job to prevent
+// possible memory leaking by capturing references to the current request, instead
+// having a constant function to which callers specify an argument on scheduling.
+// There's no interface for stopping the background go-routine for now.
+type BackgroundProcessor interface {
+	// Schedule enqueues the job to be executed in the background, in case it's not
+	// already scheduled. Returns true if job was scheduled now or false if it was
+	// already in the queue for execution.
+	Schedule(account string, arg interface{}) bool
+
+	ClearRemoteQueue() error
+}
+
+type JobFn func(interface{}) time.Duration
+
+func StartBackgroundProcessor(initialCapacity int, processFunc JobFn) BackgroundProcessor {
+	processor := &bgProcessor{
+		jobQueue:    NewSyncQueue(initialCapacity),
+		processFunc: processFunc,
+		cache:       cache.Redis(),
+	}
+	go processor.mainLoop()
+	return processor
+}
+
+type bgProcessor struct {
+	jobQueue      *SyncQueue
+	scheduledJobs sync.Map
+	cache         redis.Cache
+
+	processFunc    JobFn
+	maxJobInterval time.Duration
+}
+
+func (p *bgProcessor) Schedule(account string, arg interface{}) bool {
+	accountBackoff := getAccountBackoff(account)
+	if !p.shouldEnqueueAccount(account, accountBackoff) {
+		return false
+	}
+	p.jobQueue.Enqueue(&scheduledJob{
+		key:            account,
+		arg:            arg,
+		scheduledTime:  time.Now(),
+		accountBackoff: accountBackoff,
+	})
+	return true
+}
+
+func (p *bgProcessor) ClearRemoteQueue() error {
+	var _, err = p.cache.Incr(generationKey)
+	return err
+}
+
+func (p *bgProcessor) shouldEnqueueAccount(account string, accountBackoff time.Duration) (should bool) {
+	ttl := max(accountBackoff, p.worstCaseQueueDelay())
+	setOpts := redis.SetOptions{ExpireIn: ttl, IfNotExist: true}
+
+	keyUpdated, err := p.cache.SetOpt(p.accountHousekeepingRedisKey(account), account, setOpts)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"code":    "housekeeping_error_add_redis",
+			"account": account,
+			"error":   err.Error(),
+		}).Error("Error add account on housekeeper cache")
+	}
+	if err != nil || !keyUpdated {
+		return false
+	}
+
+	_, alreadyScheduledLocally := p.scheduledJobs.LoadOrStore(account, true)
+	if alreadyScheduledLocally {
+		return false
+	}
+
+	return true
+}
+
+func (p *bgProcessor) worstCaseQueueDelay() time.Duration {
+	return p.maxJobInterval * time.Duration(p.jobQueue.Len())
+}
+
+func max(d1, d2 time.Duration) time.Duration {
+	if d1 > d2 {
+		return d1
+	}
+	return d2
+}
+
+type scheduledJob struct {
+	key string
+	arg interface{}
+
+	scheduledTime  time.Time
+	accountBackoff time.Duration
+}
+
+func (p *bgProcessor) mainLoop() {
+	defer recoverAndLog(nil)
+
+	for {
+		metrics.GetTracker().Observe("housekeeping_queue_length", int64(p.jobQueue.Len()), nil)
+		interval := p.processOne(p.jobQueue.Dequeue().(*scheduledJob))
+		if interval > p.maxJobInterval {
+			p.maxJobInterval = interval
+		}
+		time.Sleep(interval)
+	}
+}
+
+func (p *bgProcessor) processOne(job *scheduledJob) time.Duration {
+	defer recoverAndLog(job)
+	defer p.scheduledJobs.Delete(job.key)
+	defer func() {
+		timeSinceScheduled := time.Now().Sub(job.scheduledTime)
+		remainingBackoff := job.accountBackoff - timeSinceScheduled
+		if remainingBackoff < 0 {
+			p.cache.Del(p.accountHousekeepingRedisKey(job.key))
+		} else {
+			p.cache.Set(p.accountHousekeepingRedisKey(job.key), job.key, remainingBackoff)
+		}
+	}()
+
+	return p.processFunc(job.arg)
+}
+
+func (p *bgProcessor) accountHousekeepingRedisKey(account string) string {
+	var generation int64
+	var _, err = p.cache.Get(generationKey, &generation)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"code":    "housekeeping_error_generation_incr_counter_redis",
+			"account": account,
+			"error":   err.Error(),
+		}).Error("Error incrementing generation counter")
+
+		// fall back to generation 0
+		generation = 0
+	}
+	key := fmt.Sprintf("apps:housekeeping:account:%s:generation:%s", account, strconv.FormatInt(generation, 10))
+	return key
+}
+
+func recoverAndLog(job *scheduledJob) {
+	panicVal := recover()
+	if panicVal == nil {
+		return
+	}
+
+	logger := logrus.WithFields(logrus.Fields{
+		"category":    "fatal_error",
+		"code":        "panic",
+		"source_file": "housekeeping/backgroundJob",
+		"panic_value": panicVal,
+		"stack":       string(debug.Stack()),
+	})
+	if job != nil {
+		logger = logger.WithFields(logrus.Fields{
+			"job_key":      job.key,
+			"job_argument": job.arg,
+		})
+	}
+	logger.Errorf("Panic in background processor!")
+}

--- a/worker/backgroundProcessor.go
+++ b/worker/backgroundProcessor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vtex/go-io/redis"
 )
 
-const generationKey = "goio:bgProcessor:generation"
+const generationKey = "goio.bgProcessor.generation"
 
 // BackgroundProcessor is a utility for running jobs in the background, avoiding
 // the rescheduling of the same job by a provided key. The rescheduling prevention
@@ -166,7 +166,7 @@ func (p *bgProcessor) remoteDedupKey(jobKey string) string {
 		// fallback to generation 0
 		generation = 0
 	}
-	key := fmt.Sprintf("goio:bgProcessor:dedupKey:gen:%d:jobKey:%s", generation, jobKey)
+	key := fmt.Sprintf("goio.bgProcessor.dedupKey:gen:%d:jobKey:%s", generation, jobKey)
 	return key
 }
 

--- a/worker/backgroundProcessor_test.go
+++ b/worker/backgroundProcessor_test.go
@@ -1,0 +1,140 @@
+package worker
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vtex/go-sdk/utils/metrics"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/vtex/apps/api/testutils"
+	"github.com/vtex/apps/cache"
+)
+
+func TestBackgroundProcessor(t *testing.T) {
+	cache.InitRedisWith(testutils.NewFakeRedis())
+	metrics.InitFakeTracker()
+
+	Convey("Does not schedule repeated jobs", t, withTimeout(func() {
+		blocker := make(chan struct{})
+		resultChan := make(chan bool, 1)
+		processor := StartBackgroundProcessor(5, func(interface{}) time.Duration {
+			defer close(resultChan)
+			<-blocker
+			resultChan <- true
+			return 0
+		})
+
+		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(processor.Schedule("jobKey", nil), ShouldBeFalse)
+		close(blocker)
+
+		So(<-resultChan, ShouldBeTrue)
+		_, falseIfClosed := <-resultChan
+		So(falseIfClosed, ShouldBeFalse)
+	}))
+
+	Convey("Schedules repeated jobs after executed", t, withTimeout(func() {
+		resultChan := make(chan bool, 2)
+		processor := StartBackgroundProcessor(5, func(interface{}) time.Duration {
+			resultChan <- true
+			return 0
+		})
+
+		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(<-resultChan, ShouldBeTrue)
+		time.Sleep(10 * time.Millisecond)
+
+		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(<-resultChan, ShouldBeTrue)
+	}))
+
+	Convey("Recovers from panics in jobs", t, withTimeout(func() {
+		done := make(chan struct{})
+		executed := false
+		processor := StartBackgroundProcessor(5, func(interface{}) time.Duration {
+			defer close(done)
+			executed = true
+			panic("omg! 😱")
+		})
+
+		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		<-done
+
+		So(executed, ShouldBeTrue)
+	}))
+
+	Convey("Passes arguments to jobs", t, withTimeout(func() {
+		numJobs := 100
+		wg := sync.WaitGroup{}
+		wg.Add(numJobs)
+
+		receivedArgs := map[int]bool{}
+		processor := StartBackgroundProcessor(5, func(idx interface{}) time.Duration {
+			defer wg.Done()
+			receivedArgs[idx.(int)] = true
+			return 0
+		})
+
+		for i := 0; i < numJobs; i++ {
+			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+		}
+		wg.Wait()
+
+		for i := 0; i < numJobs; i++ {
+			So(receivedArgs[i], ShouldBeTrue)
+		}
+	}))
+
+	Convey("Executes a single job at a time", t, withTimeout(func() {
+		numJobs := 50
+		wg := sync.WaitGroup{}
+		wg.Add(numJobs)
+
+		startTimes := make([]time.Time, numJobs)
+		endTimes := make([]time.Time, numJobs)
+		processor := StartBackgroundProcessor(numJobs, func(idx interface{}) time.Duration {
+			defer wg.Done()
+			startTimes[idx.(int)] = time.Now()
+			time.Sleep(5 * time.Millisecond)
+			endTimes[idx.(int)] = time.Now()
+			return 0
+		})
+
+		for i := 0; i < numJobs; i++ {
+			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+		}
+		wg.Wait()
+
+		for i := 1; i < numJobs; i++ {
+			timeAfterLast := startTimes[i].Sub(endTimes[i-1])
+			So(timeAfterLast, ShouldBeGreaterThanOrEqualTo, 0)
+		}
+	}))
+
+	Convey("Does wait interval between jobs", t, withTimeout(func() {
+		numJobs := 50
+		execInterval := 7 * time.Millisecond
+		wg := sync.WaitGroup{}
+		wg.Add(numJobs)
+
+		execTimes := make([]time.Time, numJobs)
+		processor := StartBackgroundProcessor(numJobs, func(idx interface{}) time.Duration {
+			defer wg.Done()
+			execTimes[idx.(int)] = time.Now()
+			return execInterval
+		})
+
+		for i := 0; i < numJobs; i++ {
+			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+		}
+		wg.Wait()
+
+		for i := 1; i < numJobs; i++ {
+			timeAfterLast := execTimes[i].Sub(execTimes[i-1])
+			So(timeAfterLast, ShouldBeGreaterThanOrEqualTo, execInterval)
+		}
+	}))
+}

--- a/worker/backgroundProcessor_test.go
+++ b/worker/backgroundProcessor_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestBackgroundProcessor(t *testing.T) {
 	redis := stubs.NewRedis()
+	backoff := 1 * time.Second
 
 	Convey("Does not schedule repeated jobs", t, withTimeout(func() {
 		blocker := make(chan struct{})
@@ -23,8 +24,8 @@ func TestBackgroundProcessor(t *testing.T) {
 			return 0
 		})
 
-		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
-		So(processor.Schedule("jobKey", nil), ShouldBeFalse)
+		So(processor.Schedule("jobKey", backoff, nil), ShouldBeTrue)
+		So(processor.Schedule("jobKey", backoff, nil), ShouldBeFalse)
 		close(blocker)
 
 		So(<-resultChan, ShouldBeTrue)
@@ -39,11 +40,11 @@ func TestBackgroundProcessor(t *testing.T) {
 			return 0
 		})
 
-		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(processor.Schedule("jobKey", backoff, nil), ShouldBeTrue)
 		So(<-resultChan, ShouldBeTrue)
 		time.Sleep(10 * time.Millisecond)
 
-		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(processor.Schedule("jobKey", backoff, nil), ShouldBeTrue)
 		So(<-resultChan, ShouldBeTrue)
 	}))
 
@@ -56,7 +57,7 @@ func TestBackgroundProcessor(t *testing.T) {
 			panic("omg! 😱")
 		})
 
-		So(processor.Schedule("jobKey", nil), ShouldBeTrue)
+		So(processor.Schedule("jobKey", backoff, nil), ShouldBeTrue)
 		<-done
 
 		So(executed, ShouldBeTrue)
@@ -75,7 +76,7 @@ func TestBackgroundProcessor(t *testing.T) {
 		})
 
 		for i := 0; i < numJobs; i++ {
-			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+			So(processor.Schedule(fmt.Sprint("job", i), backoff, i), ShouldBeTrue)
 		}
 		wg.Wait()
 
@@ -100,7 +101,7 @@ func TestBackgroundProcessor(t *testing.T) {
 		})
 
 		for i := 0; i < numJobs; i++ {
-			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+			So(processor.Schedule(fmt.Sprint("job", i), backoff, i), ShouldBeTrue)
 		}
 		wg.Wait()
 
@@ -124,7 +125,7 @@ func TestBackgroundProcessor(t *testing.T) {
 		})
 
 		for i := 0; i < numJobs; i++ {
-			So(processor.Schedule(fmt.Sprint("job", i), i), ShouldBeTrue)
+			So(processor.Schedule(fmt.Sprint("job", i), backoff, i), ShouldBeTrue)
 		}
 		wg.Wait()
 

--- a/worker/syncQueue.go
+++ b/worker/syncQueue.go
@@ -1,0 +1,81 @@
+package worker
+
+import (
+	"sync"
+)
+
+// SyncQueue is a helper for a (channel-like) queue that allows multiple concurrent
+// senders and receivers and never blocks indefinitely on enqueueuing by resizing
+// the internal channel when full. It doesn't guarantee execution order when
+// queue resizes occur but that should stop once queue size stabilizes.
+type SyncQueue struct {
+	resizeLock sync.RWMutex
+	queue      chan interface{}
+}
+
+func NewSyncQueue(initialCapacity int) *SyncQueue {
+	if initialCapacity <= 0 {
+		panic("Sync queue capacity must be greater than zero")
+	}
+	return &SyncQueue{
+		queue: make(chan interface{}, initialCapacity),
+	}
+}
+
+func (q *SyncQueue) Enqueue(item interface{}) {
+	for !q.tryEnqueue(item) {
+		q.resize()
+	}
+}
+
+func (q *SyncQueue) Dequeue() interface{} {
+	for {
+		if item, ok := <-q.queue; ok {
+			return item
+		}
+		// If channel was closed a resize operation is taking place. Lock&unlock to wait
+		// for it to finish and try again.
+		q.resizeLock.RLock()
+		q.resizeLock.RUnlock()
+	}
+}
+
+func (q *SyncQueue) Len() int {
+	return len(q.queue)
+}
+
+func (q *SyncQueue) tryEnqueue(item interface{}) bool {
+	q.resizeLock.RLock()
+	defer q.resizeLock.RUnlock()
+	select {
+	case q.queue <- item:
+		return true
+	default:
+		return false
+	}
+}
+
+func (q *SyncQueue) resize() {
+	q.resizeLock.Lock()
+	defer q.resizeLock.Unlock()
+
+	if hasSpaceInBuffer(q.queue) {
+		// Queue probably resized by some other routine
+		return
+	}
+
+	close(q.queue)
+	resized := make(chan interface{}, 2*cap(q.queue))
+	for item := range q.queue {
+		resized <- item
+	}
+	q.queue = resized
+}
+
+// We use a simple heuristic to say if there is enough space in the buffer which
+// is checking if at least a third of its capacity is still unused. Checking only
+// if len < cap would be bug-prone as a single concurrent receive in the channel
+// could make that become true and we get stuck in a tryEnqueue-resize loop.
+func hasSpaceInBuffer(c <-chan interface{}) bool {
+	return 3*len(c) <= 2*cap(c)
+}

--- a/worker/syncQueue_test.go
+++ b/worker/syncQueue_test.go
@@ -1,0 +1,140 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const defaultTimeout = 1 * time.Second
+
+func TestSyncQueue(t *testing.T) {
+	Convey("Disallow creating empty queue", t, withTimeout(func() {
+		So(func() {
+			NewSyncQueue(0)
+		}, ShouldPanic)
+	}))
+
+	Convey("Should never block on enqueueing", t, withTimeout(func() {
+		initCap := 10
+		queue := NewSyncQueue(initCap)
+
+		Convey("Without exceeding capacity", func() {
+			populateQueue(queue, initCap)
+		})
+		Convey("Exceeding capacity by 10", func() {
+			populateQueue(queue, 10*initCap)
+		})
+		Convey("Exceeding capacity by 100", func() {
+			populateQueue(queue, 100*initCap)
+		})
+	}))
+
+	Convey("Should keep insertion order without resizes", t, withTimeout(func() {
+		numItems := 100
+		queue := NewSyncQueue(numItems)
+
+		go populateQueue(queue, numItems)
+
+		for i := 0; i < numItems; i++ {
+			So(queue.Dequeue(), ShouldEqual, i)
+		}
+	}))
+
+	Convey("Should not lose items even with resizes", t, withTimeout(func() {
+		numItems := 100
+		queue := NewSyncQueue(1)
+
+		Convey("Single sender", func() {
+			go populateQueue(queue, numItems)
+
+			Convey("Single receiver", func() {
+				received := consumeQueue(queue, numItems)
+				So(len(received), ShouldEqual, numItems)
+			})
+			Convey("Multiple receivers", func() {
+				received := concurrentConsumeQueue(queue, numItems)
+				So(len(received), ShouldEqual, numItems)
+			})
+		})
+
+		Convey("Multiple senders", func() {
+			go concurrentPopulateQueue(queue, numItems)
+
+			Convey("Single receiver", func() {
+				received := consumeQueue(queue, numItems)
+				So(len(received), ShouldEqual, numItems)
+			})
+			Convey("Multiple receivers", func() {
+				received := concurrentConsumeQueue(queue, numItems)
+				So(len(received), ShouldEqual, numItems)
+			})
+		})
+	}))
+}
+
+func withTimeout(f func()) func() {
+	return func() {
+		done := make(chan struct{})
+		defer close(done)
+
+		go func() {
+			select {
+			case <-done:
+			case <-time.After(defaultTimeout):
+				panic("Timeout in SyncQueue tests!")
+			}
+		}()
+
+		f()
+	}
+}
+
+func populateQueue(queue *SyncQueue, numItems int) {
+	for i := 0; i < numItems; i++ {
+		queue.Enqueue(i)
+	}
+}
+
+func concurrentPopulateQueue(queue *SyncQueue, numItems int) {
+	for i := 0; i < numItems; i++ {
+		go queue.Enqueue(i)
+	}
+}
+
+func consumeQueue(queue *SyncQueue, numItems int) map[int]bool {
+	received := map[int]bool{}
+	for i := 0; i < numItems; i++ {
+		receivedVal := queue.Dequeue().(int)
+		if received[receivedVal] {
+			panic("Duplicate value received!")
+		}
+		received[receivedVal] = true
+	}
+	return received
+}
+
+func concurrentConsumeQueue(queue *SyncQueue, numItems int) map[int]bool {
+	receivedChan := make(chan int, numItems)
+	wg := sync.WaitGroup{}
+	wg.Add(numItems)
+	for i := 0; i < numItems; i++ {
+		go func() {
+			defer wg.Done()
+			receivedChan <- queue.Dequeue().(int)
+		}()
+	}
+	wg.Wait()
+	close(receivedChan)
+
+	received := map[int]bool{}
+	for receivedVal := range receivedChan {
+		if received[receivedVal] {
+			panic("Duplicate value received!")
+		}
+		received[receivedVal] = true
+	}
+	return received
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to move and open source the sync queue and background processor
from housekeeeper. They've been working pretty fine in the last months and
with a pretty nice impl and docs IMHO (🙈) so I think it's worth including them
in our open-sourced tools.

Mostly copied the files then went through the code removing any references to
the existing projects (both code and concepts). 

#### What problem is this solving?
Not enough public general-purpose tools/code developed and maintained by the company.
Employer branding :allthethings:

#### How should this be manually tested?
 - `make test`
 - Also replace it on apps and make sure it's as usable as before (which I made sure it was possible).
   - The only thing to remember is that I removed the queue length metric, so we have to update our job processFunc to send it instead, using the `QueueLength` function now being exposed.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
