### PR TITLE
Add Broker&BrokerPool implementation from Colossus

### DIFF
--- a/event/broker.go
+++ b/event/broker.go
@@ -1,0 +1,127 @@
+package event
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// Broker provides a friendly interface to fan-out events to as many subscribers
+// registered with it. Notice that an explicit unsubscription is necessary even
+// with a context.Context being sent on the subscription call (to be improved).
+type Broker interface {
+	Subscribe(ctx context.Context) (EventSource, error)
+	Unsubscribe(src EventSource) (hasMore bool, err error)
+}
+
+type broker struct {
+	ctx    context.Context
+	source EventSource
+
+	lock    sync.Mutex
+	clients []client
+}
+
+type client struct {
+	C   chan Event
+	ctx context.Context
+}
+
+func NewBroker(ctx context.Context, source EventSource) Broker {
+	b := &broker{
+		ctx:     ctx,
+		source:  source,
+		clients: make([]client, 0, 10),
+	}
+	go b.sendEventsLoop()
+	return b
+}
+
+func (b *broker) sendEventsLoop() {
+	defer b.unsubscribeAll()
+
+	for {
+		select {
+		case ev, ok := <-b.source:
+			if !ok {
+				return
+			}
+			b.sendToClients(ev)
+
+		case <-b.ctx.Done():
+			return
+		}
+	}
+}
+
+func (b *broker) isStopped() bool {
+	select {
+	case <-b.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *broker) sendToClients(ev Event) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	for _, client := range b.clients {
+		select {
+		case client.C <- ev:
+		case <-client.ctx.Done():
+			// client done, simply ignore them until they're properly unsubscribed
+		case <-b.ctx.Done():
+			return
+		}
+	}
+}
+
+func (b *broker) Subscribe(ctx context.Context) (EventSource, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.isStopped() {
+		return nil, errors.New("Attempt to subscribe to an already stopped broker")
+	}
+
+	ch := make(chan Event, 1)
+	b.clients = append(b.clients, client{ch, ctx})
+
+	return ch, nil
+}
+
+func (b *broker) Unsubscribe(client EventSource) (hasMore bool, err error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	idx := findClientIdx(b.clients, client)
+	if idx < 0 {
+		return len(b.clients) > 0, errors.New("Tried to unsubscribe inexistent client")
+	}
+
+	close(b.clients[idx].C)
+	b.clients = append(b.clients[:idx], b.clients[idx+1:]...)
+	return len(b.clients) > 0, nil
+}
+
+func (b *broker) unsubscribeAll() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	for _, cl := range b.clients {
+		close(cl.C)
+	}
+	b.clients = nil
+}
+
+func findClientIdx(clients []client, elm <-chan Event) int {
+	for i, cl := range clients {
+		if cl.C == elm {
+			return i
+		}
+	}
+	return -1
+}

--- a/event/brokerPool.go
+++ b/event/brokerPool.go
@@ -1,0 +1,130 @@
+package event
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type EventSourceFactory func(ctx context.Context, id string, arg interface{}) (EventSource, error)
+
+// BrokerPool manages a group of brokers which can be accessed and retrieved via an ID.
+// It also simplifies the access to the brokers themselves, providing a single Subscribe
+// function which automatically makes the unsubscription when the context is cancelled.
+//
+// The EventSourceFactory passed as argument to the constructor should create a new
+// EventSource channel, using the optional factoryArg that is passed on subscription.
+//
+// In the simplest case, for example for messaging events between internal application
+// components, there could be a single set of EventSources and the factory would grab them
+// by their ID and return otherwise return an error for inexistent event source. In more
+// complex scenarios, these event sources could be actual subscriptions to some remote
+// messaging service for example Redis or RabbitMQ.
+type BrokerPool interface {
+	Subscribe(ctx context.Context, id string, factoryArg interface{}) (EventSource, error)
+}
+
+func NewPool(factory EventSourceFactory) BrokerPool {
+	return &brokerPool{
+		factory: factory,
+		brokers: map[string]*poolEntry{},
+	}
+}
+
+type brokerPool struct {
+	factory EventSourceFactory
+
+	lock    sync.RWMutex
+	brokers map[string]*poolEntry
+}
+
+type poolEntry struct {
+	id     string
+	broker Broker
+	stopFn func()
+}
+
+func (p *brokerPool) Subscribe(ctx context.Context, id string, factoryArg interface{}) (EventSource, error) {
+	p.lock.RLock()
+	if entry, ok := p.brokers[id]; ok {
+		defer p.lock.RUnlock()
+		return p.subscribeLocked(ctx, entry)
+	}
+	p.lock.RUnlock()
+
+	entry, err := p.createBroker(id, factoryArg)
+	if err != nil {
+		return nil, err
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if existing, ok := p.brokers[id]; ok {
+		entry.stopFn()
+		entry = existing
+	} else {
+		p.brokers[id] = entry
+	}
+
+	return p.subscribeLocked(ctx, entry)
+}
+
+func (p *brokerPool) createBroker(id string, factoryArg interface{}) (*poolEntry, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	source, err := p.factory(ctx, id, factoryArg)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	broker := NewBroker(ctx, source)
+	return &poolEntry{id, broker, cancel}, nil
+}
+
+// This function must be called in whilst locked in the broker pool, otherwise
+// it could be executed concurrently with the unsubscribe function below, which
+// could cause an invalid state to arise. It could be an RLock just fine, as the
+// unsubscribe always grab a (W)Lock itself.
+//
+// e.g. If not locked, unsubscribe could stop and remove the broker from the
+// pool right before this one attempts to create a subscription.
+func (p *brokerPool) subscribeLocked(ctx context.Context, entry *poolEntry) (EventSource, error) {
+	sub, err := entry.broker.Subscribe(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		p.unsubscribe(entry, sub)
+	}()
+	return sub, nil
+}
+
+func (p *brokerPool) unsubscribe(entry *poolEntry, sub EventSource) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if _, ok := p.brokers[entry.id]; !ok {
+		logrus.WithFields(logrus.Fields{
+			"code":   "broker_not_found_err",
+			"subsId": entry.id,
+		}).Error("Unsubscribing from broker not in pool anymore")
+	}
+
+	hasMore, err := entry.broker.Unsubscribe(sub)
+	if err != nil {
+		logrus.WithError(err).
+			WithFields(logrus.Fields{
+				"code":   "broker_unsubscribe_err",
+				"subsId": entry.id,
+			}).
+			Error("Thought valid subscription not found in origin broker")
+	}
+	if !hasMore {
+		delete(p.brokers, entry.id)
+		entry.stopFn()
+	}
+}

--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,16 @@
+package event
+
+type EventSource <-chan Event
+
+type Event struct {
+	Type string
+	Data interface{}
+}
+
+func NewEvent(data interface{}) Event {
+	return Event{Data: data}
+}
+
+func NewTypedEvent(_type string, data interface{}) Event {
+	return Event{Type: _type, Data: data}
+}


### PR DESCRIPTION
Back in the day, we had this implementation before
the actual subscriptions to Redis. At some point I
realized the all pubsub logic we have in the
redis/pubsub.go client made all this brokering logic
unnecessary.

I still think this is some pretty good code though,
and had it sitting in my local go-io repository for
quite a while now.

So let's just commit and open source it, and maybe
it can be useful for anyone in the future :)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
