### PR TITLE
Added a getRegisterer to prometheus client

### DIFF
--- a/prometheus/client.go
+++ b/prometheus/client.go
@@ -72,6 +72,14 @@ func InitClient() {
 	client = &prometheusClient{}
 }
 
+func GetRegisterer() prometheus.Registerer {
+	if client == nil {
+		panic("Can't get registerer before initing client")
+	}
+
+	return prometheus.DefaultRegisterer
+}
+
 func GetClient() PrometheusClient {
 	if client == nil {
 		panic("Init the prometheus client before access it")


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add a method that retrieves the Prometheus registerer used by the client

#### What problem is this solving?
To be able to correctly send a registerer to our metrics interface.
Related to https://github.com/vtex/go-sdk/pull/67

#### How should this be manually tested?
```
prometheus.InitClient()
promRegisterer := prometheus.GetRegisterer()
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
