### PR TITLE
Bubbling up the same error that redigo uses so that the logic to shor…

### DIFF
--- a/redis/cache.go
+++ b/redis/cache.go
@@ -202,7 +202,7 @@ func (r *redisC) doCmd(cmd string, args ...interface{}) (interface{}, error) {
 		defer r.conf.TimeTracker(commandKpiName(cmd), time.Now())
 		result, err := r.cluster.Do(context.Background(), append([]interface{}{cmd}, args...)...).Result()
 		if err == redisCluster.Nil {
-			return result, nil
+			return result, redis.ErrNil
 		}
 
 		return result, err


### PR DESCRIPTION
…t circuit cache is consistent when using cluster mode

#### What is the purpose of this pull request?
I believe this may be the source of our 404 troubles since we aren't short circuiting the same way as we were before when using redigo. With this change it will bubble up the same error that we were getting and cause it to follow the same logic.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
I have a suspicion that since this isn't short circuiting and returning false that we are indicating to the caller that there was no error and that the content was nil.

#### How should this be manually tested?
Not really sure tbh

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
